### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,68 @@
+# Line ending normalization
+# All text files default to LF
+* text=auto eol=lf
+
+# Explicit text files
+*.py text eol=lf
+*.dart text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.sh text eol=lf
+*.tf text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.sql text eol=lf
+*.toml text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+*.env text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
+Dockerfile text eol=lf
+.dockerignore text eol=lf
+
+# Windows-specific files keep CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files (no line ending processing)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.db binary
+*.sqlite binary
+*.pyc binary
+*.pyo binary
+*.so binary
+*.dylib binary
+*.dll binary
+*.exe binary
+*.jar binary
+*.class binary
+
+# Flutter/Dart specific binaries
+*.dart_tool binary
+
+# Generated/lock files treated as text but without diff noise
+package-lock.json text eol=lf
+pubspec.lock text eol=lf
+Podfile.lock text eol=lf


### PR DESCRIPTION
Introduces a repository-wide line-ending policy:
- All text files default to LF
- Windows-specific files (.bat, .cmd, .ps1) keep CRLF
- Binary file types explicitly marked
- Flutter/Dart, Python, Terraform, TypeScript all LF

The index already contains LF-normalized blobs from prior renormalization work, so this commit only adds the .gitattributes file itself. Future commits will be automatically enforced against this policy.

Contributors on Windows should set:
  git config --global core.autocrlf false
  git config --global core.eol lf

Local working tree files with CRLF are harmless — git delivers the correct line endings per platform on checkout.